### PR TITLE
Revert "Update hubs.yaml"

### DIFF
--- a/hubs.yaml
+++ b/hubs.yaml
@@ -19,28 +19,3 @@ hubs:
         singleuser:
           memory:
             limit: 1G
-  - name: holdgraf
-    domain: holdgraf.alpha.2i2c.cloud
-    auth0:
-      connection: google-oauth2
-    config:
-      jupyterhub:
-        auth:
-          # Admin names need to be listed wtice here, unfortunately
-          # 'whitelist' will be removed by next jupyterhub release
-          whitelist:
-            users:
-              - choldgraf@gmail.com
-              - yuvipanda@gmail.com
-              - colliand@gmail.com
-          admin:
-            users:
-              - choldgraf@gmail.com
-              - yuvipanda@gmail.com
-              - colliand@gmail.com
-        singleuser:
-          memory:
-            limit: 1G
-          image:
-            name: jupyter/datascience-notebook
-            tag: latest


### PR DESCRIPTION
Reverts 2i2c-org/low-touch-hubs#8

looks like we hit some kinda cloud limit so I'm reverting. Here is the error message:

https://github.com/2i2c-org/low-touch-hubs/runs/1183685718#step:8:40